### PR TITLE
fix: Add DM-based preview for context menu flows

### DIFF
--- a/src/cogs/create_issue.py
+++ b/src/cogs/create_issue.py
@@ -7,6 +7,7 @@ from discord.errors import NotFound
 from discord.ext import commands
 
 from src.cogs.registry import register_handler
+from src.cogs.response import DmResponseTarget, ResponseTarget
 from src.cogs.ui import build_error_embed
 from src.pipeline.create_issue import IssuePipeline
 from src.utils.discord import fetch_messages_with_metadata
@@ -70,6 +71,7 @@ class CreateIssueCog(commands.Cog):
         topic: str,
         n: int,
         anchor: discord.Message | None = None,
+        target: ResponseTarget | None = None,
     ) -> None:
         """Defer, resolve an anchor message, fetch context around it, and hand off to the pipeline."""
         t0 = time.monotonic()
@@ -127,6 +129,7 @@ class CreateIssueCog(commands.Cog):
                 messages=fetch_result.messages,
                 latest_message_link=fetch_result.latest_message_link,
                 ephemeral=True,
+                target=target,
             )
             logger.info(
                 "create-issue complete (%.0fms)", (time.monotonic() - t0) * 1000
@@ -181,4 +184,5 @@ class CreateIssueModal(discord.ui.Modal, title="Create Issue"):
             topic=self.topic.value,
             n=n,
             anchor=self.target_message,
+            target=DmResponseTarget(interaction.user, interaction.channel_id),
         )

--- a/src/cogs/engine_issue.py
+++ b/src/cogs/engine_issue.py
@@ -6,6 +6,7 @@ from discord import app_commands
 from discord.errors import NotFound
 from discord.ext import commands
 
+from src.cogs.response import DmResponseTarget, ResponseTarget
 from src.cogs.ui import build_error_embed
 from src.pipeline.create_issue import IssuePipeline
 from src.utils.discord import fetch_messages_with_metadata
@@ -65,6 +66,7 @@ class EngineIssueCog(commands.Cog):
         topic: str,
         n: int,
         anchor: discord.Message | None = None,
+        target: ResponseTarget | None = None,
     ) -> None:
         """Defer, resolve an anchor message, fetch context around it, and hand off to the pipeline."""
         t0 = time.monotonic()
@@ -121,6 +123,7 @@ class EngineIssueCog(commands.Cog):
                 messages=fetch_result.messages,
                 latest_message_link=fetch_result.latest_message_link,
                 ephemeral=True,
+                target=target,
             )
             logger.info(
                 "engine-issue complete (%.0fms)", (time.monotonic() - t0) * 1000
@@ -169,4 +172,5 @@ class EngineIssueModal(discord.ui.Modal, title="Engine Issue"):
             topic=self.topic.value,
             n=n,
             anchor=self.target_message,
+            target=DmResponseTarget(interaction.user, interaction.channel_id),
         )

--- a/src/cogs/response.py
+++ b/src/cogs/response.py
@@ -1,0 +1,63 @@
+import discord
+
+_FORBIDDEN_MSG = (
+    "I couldn't DM you. Please enable DMs from server members and try again."
+)
+
+
+class ResponseTarget:
+    """Default delivery: edit the loading message in place (ephemeral followup)."""
+
+    async def send_preview(self, loading_msg, embed: discord.Embed, view) -> None:
+        await loading_msg.edit(embed=embed, view=view)
+
+    async def send_error(
+        self, loading_msg, embed: discord.Embed, view=None
+    ) -> None:
+        if view is not None:
+            await loading_msg.edit(embed=embed, view=view)
+        else:
+            await loading_msg.edit(embed=embed)
+
+    @property
+    def channel_id(self) -> int | None:
+        return None
+
+
+class DmResponseTarget(ResponseTarget):
+    """Send previews and errors to the user's DMs; leave a stub in-channel."""
+
+    def __init__(
+        self,
+        user: discord.User | discord.Member,
+        origin_channel_id: int,
+    ) -> None:
+        self._user = user
+        self._origin_channel_id = origin_channel_id
+
+    async def send_preview(self, loading_msg, embed: discord.Embed, view) -> None:
+        try:
+            await self._user.send(embed=embed, view=view)
+            await loading_msg.edit(
+                content="Check your DMs for the issue preview.", embed=None
+            )
+        except discord.Forbidden:
+            await loading_msg.edit(content=_FORBIDDEN_MSG, embed=None)
+
+    async def send_error(
+        self, loading_msg, embed: discord.Embed, view=None
+    ) -> None:
+        try:
+            if view is not None:
+                await self._user.send(embed=embed, view=view)
+            else:
+                await self._user.send(embed=embed)
+            await loading_msg.edit(
+                content="Check your DMs for details.", embed=None
+            )
+        except discord.Forbidden:
+            await loading_msg.edit(content=_FORBIDDEN_MSG, embed=None)
+
+    @property
+    def channel_id(self) -> int | None:
+        return self._origin_channel_id

--- a/src/pipeline/create_issue.py
+++ b/src/pipeline/create_issue.py
@@ -6,6 +6,7 @@ from src.models import CachedCommandData, CachedOutputData, PipelineData
 from src.output.github import RepoNotInstalled, append_footer
 from src.output.github_client import GitHubClient
 from src.transform.transform import Transform
+from src.cogs.response import ResponseTarget
 from src.cogs.ui import (
     DeleteView,
     ErrorView,
@@ -100,8 +101,12 @@ class IssuePipeline:
         messages: list[str],
         latest_message_link: str | None,
         ephemeral: bool = False,
+        target: ResponseTarget | None = None,
     ) -> None:
         """Check repo installation, run the LLM transform, and display a preview with confirm/retry/cancel buttons."""
+        if target is None:
+            target = ResponseTarget()
+
         data = self.build_pipeline_data(topic, messages)
 
         owner, repo_name = repo.split("/", 1)
@@ -125,7 +130,7 @@ class IssuePipeline:
                 ),
                 color=discord.Color.red(),
             )
-            await loading_msg.edit(embed=embed)
+            await target.send_error(loading_msg, embed)
             return
 
         cached = self.build_cached_data(
@@ -135,6 +140,8 @@ class IssuePipeline:
             owner=owner,
             repo=repo_name,
         )
+        if target.channel_id is not None:
+            cached.extra["channel_id"] = target.channel_id
         retry_key = cache_pipeline_data(cached)
 
         try:
@@ -143,7 +150,7 @@ class IssuePipeline:
             logger.exception("Transform failed")
             embed = build_error_embed(exc)
             view = ErrorView(cmd_type=self.CMD_TYPE, retry_key=retry_key)
-            await loading_msg.edit(embed=embed, view=view)
+            await target.send_error(loading_msg, embed, view)
             return
 
         view = PreviewView(
@@ -153,7 +160,7 @@ class IssuePipeline:
         )
 
         embed = discord.Embed(description=result.input)
-        await loading_msg.edit(embed=embed, view=view)
+        await target.send_preview(loading_msg, embed, view)
 
     # ------------------------------------------------------------------
     # CommandHandler protocol (dispatched by UI buttons)
@@ -176,18 +183,23 @@ class IssuePipeline:
         owner = cached.extra["owner"]
         repo = cached.extra["repo"]
 
+        channel_id = cached.extra.get("channel_id")
+
         try:
             url = await self.create_issue(owner, repo, title, body)
         except Exception as exc:
             logger.exception("Failed to create issue on GitHub")
+            payload = {
+                "title": title,
+                "body": body,
+                "owner": owner,
+                "repo": repo,
+            }
+            if channel_id is not None:
+                payload["channel_id"] = channel_id
             github_data = CachedOutputData(
                 cmd_type=self.CMD_TYPE,
-                payload={
-                    "title": title,
-                    "body": body,
-                    "owner": owner,
-                    "repo": repo,
-                },
+                payload=payload,
             )
             new_key = cache_pipeline_data(github_data)
             embed = build_error_embed(exc)
@@ -198,7 +210,12 @@ class IssuePipeline:
         await interaction.response.edit_message(
             content=f"Issue created: {url}", view=None
         )
-        await interaction.channel.send(
+        channel = (
+            interaction.client.get_channel(channel_id)
+            if channel_id
+            else interaction.channel
+        )
+        await channel.send(
             content=f"Issue created: {url}", view=DeleteView()
         )
 
@@ -237,11 +254,17 @@ class IssuePipeline:
         owner = cached.payload["owner"]
         repo = cached.payload["repo"]
 
+        channel_id = cached.payload.get("channel_id")
+
         try:
             url = await self.create_issue(owner, repo, title, body)
         except Exception as exc:
             logger.exception("GitHub retry failed")
-            new_key = cache_pipeline_data(cached)
+            retry_data = CachedOutputData(
+                cmd_type=self.CMD_TYPE,
+                payload=cached.payload,
+            )
+            new_key = cache_pipeline_data(retry_data)
             embed = build_error_embed(exc)
             view = OutputErrorView(cmd_type=self.CMD_TYPE, retry_key=new_key)
             await interaction.response.edit_message(embed=embed, view=view)
@@ -250,6 +273,11 @@ class IssuePipeline:
         await interaction.response.edit_message(
             content=f"Issue created: {url}", embed=None, view=None
         )
-        await interaction.channel.send(
+        channel = (
+            interaction.client.get_channel(channel_id)
+            if channel_id
+            else interaction.channel
+        )
+        await channel.send(
             content=f"Issue created: {url}", view=DeleteView()
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,8 +113,10 @@ def mock_interaction():
     interaction = AsyncMock()
     interaction.response = AsyncMock()
     interaction.response.is_done = MagicMock(return_value=True)
-    interaction.channel = MagicMock()
+    interaction.channel = AsyncMock()
+    interaction.channel_id = 12345
     interaction.client = MagicMock()
+    interaction.client.get_channel = MagicMock(return_value=AsyncMock())
     interaction.user = MagicMock()
     interaction.user.display_name = "TestUser"
     return interaction
@@ -128,17 +130,21 @@ def make_cached(
     cmd_type="issue",
     owner="test-owner",
     repo="test-repo",
+    channel_id=None,
 ):
     pipeline = PipelineData(input=input, context={"messages": messages or ["msg"]})
+    extra = {
+        "author_username": author,
+        "latest_message_link": link,
+        "owner": owner,
+        "repo": repo,
+    }
+    if channel_id is not None:
+        extra["channel_id"] = channel_id
     return CachedCommandData(
         cmd_type=cmd_type,
         pipeline_data=pipeline,
-        extra={
-            "author_username": author,
-            "latest_message_link": link,
-            "owner": owner,
-            "repo": repo,
-        },
+        extra=extra,
     )
 
 

--- a/tests/test_create_issue.py
+++ b/tests/test_create_issue.py
@@ -5,6 +5,7 @@ import discord
 import pytest
 
 from src.cogs.create_issue import CreateIssueCog, CreateIssueModal
+from src.cogs.response import DmResponseTarget
 from src.utils.discord import FetchResult
 from src.pipeline.create_issue import IssuePipeline
 
@@ -131,7 +132,28 @@ class TestCreateIssueCog:
                 messages=["user1: hello", "user2: world"],
                 latest_message_link="https://discord.com/channels/1/2/3",
                 ephemeral=True,
+                target=None,
             )
+
+    @pytest.mark.asyncio
+    @patch("src.cogs.create_issue.fetch_messages_with_metadata")
+    async def test_run_passes_target_to_pipeline(self, mock_fetch, cog):
+        mock_fetch.return_value = _mock_fetch_result()
+        anchor = _mock_message()
+        interaction = _mock_interaction()
+        target = MagicMock()
+
+        with patch.object(cog.pipeline, "run", new_callable=AsyncMock) as mock_run:
+            await cog._run(
+                interaction,
+                repo="owner/repo",
+                topic="bug",
+                n=5,
+                anchor=anchor,
+                target=target,
+            )
+
+            assert mock_run.call_args.kwargs["target"] is target
 
     @pytest.mark.asyncio
     async def test_run_empty_channel_sends_error(self, cog):
@@ -196,7 +218,7 @@ class TestCreateIssueModal:
         assert hasattr(modal, "n")
 
     @pytest.mark.asyncio
-    async def test_on_submit_delegates_to_run_with_anchor(self, cog):
+    async def test_on_submit_delegates_to_run_with_anchor_and_dm_target(self, cog):
         msg = _mock_message()
         modal = CreateIssueModal(msg, cog=cog)
         modal.repo._value = "owner/repo"
@@ -207,13 +229,15 @@ class TestCreateIssueModal:
         with patch.object(cog, "_run", new_callable=AsyncMock) as mock_run:
             await modal.on_submit(interaction)
 
-            mock_run.assert_awaited_once_with(
-                interaction,
-                repo="owner/repo",
-                topic="bug report",
-                n=15,
-                anchor=msg,
-            )
+            mock_run.assert_awaited_once()
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["repo"] == "owner/repo"
+            assert call_kwargs["topic"] == "bug report"
+            assert call_kwargs["n"] == 15
+            assert call_kwargs["anchor"] is msg
+            target = call_kwargs["target"]
+            assert isinstance(target, DmResponseTarget)
+            assert target.channel_id == interaction.channel_id
 
     @pytest.mark.asyncio
     async def test_on_submit_defaults_n_when_blank(self, cog):

--- a/tests/test_engine_issue.py
+++ b/tests/test_engine_issue.py
@@ -4,6 +4,7 @@ import discord
 import pytest
 
 from src.cogs.engine_issue import EngineIssueCog, EngineIssueModal, REPO
+from src.cogs.response import DmResponseTarget
 from src.utils.discord import FetchResult
 from src.pipeline.create_issue import IssuePipeline
 
@@ -118,6 +119,7 @@ class TestEngineIssueCog:
                 messages=["user1: msg"],
                 latest_message_link="https://discord.com/channels/1/2/3",
                 ephemeral=True,
+                target=None,
             )
 
     @pytest.mark.asyncio
@@ -178,7 +180,7 @@ class TestEngineIssueModal:
         assert hasattr(modal, "n")
 
     @pytest.mark.asyncio
-    async def test_on_submit_delegates_to_run_with_anchor(self, cog):
+    async def test_on_submit_delegates_to_run_with_anchor_and_dm_target(self, cog):
         msg = _mock_message()
         modal = EngineIssueModal(msg, cog=cog)
         modal.topic._value = "bug report"
@@ -188,12 +190,14 @@ class TestEngineIssueModal:
         with patch.object(cog, "_run", new_callable=AsyncMock) as mock_run:
             await modal.on_submit(interaction)
 
-            mock_run.assert_awaited_once_with(
-                interaction,
-                topic="bug report",
-                n=15,
-                anchor=msg,
-            )
+            mock_run.assert_awaited_once()
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["topic"] == "bug report"
+            assert call_kwargs["n"] == 15
+            assert call_kwargs["anchor"] is msg
+            target = call_kwargs["target"]
+            assert isinstance(target, DmResponseTarget)
+            assert target.channel_id == interaction.channel_id
 
     @pytest.mark.asyncio
     async def test_on_submit_defaults_n_when_blank(self, cog):

--- a/tests/test_issue_pipeline.py
+++ b/tests/test_issue_pipeline.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import discord
 import pytest
 
+from src.cogs.response import ResponseTarget
 from src.pipeline.create_issue import IssuePipeline
 from src.models import PipelineData
 from src.output.github import RepoNotInstalled
@@ -349,6 +350,266 @@ class TestOnRetry:
         view = interaction.edit_original_response.call_args.kwargs["view"]
         retry_btn = [c for c in view.children if isinstance(c, RetryButton)][0]
         assert retry_btn.retry_key != original_key
+
+
+# ------------------------------------------------------------------
+# DM flow in pipeline.run()
+# ------------------------------------------------------------------
+
+
+class TestRunWithTarget:
+    @pytest.mark.asyncio
+    async def test_target_send_preview_called_on_success(self, mock_pipeline):
+        interaction = _mock_interaction()
+        target = AsyncMock(spec=ResponseTarget)
+        target.channel_id = 99999
+        loading_msg = AsyncMock()
+        interaction.followup.send.return_value = loading_msg
+
+        await mock_pipeline.run(
+            interaction,
+            repo="owner/repo",
+            topic="bug",
+            messages=["user1: msg"],
+            latest_message_link=None,
+            target=target,
+        )
+        target.send_preview.assert_awaited_once()
+        call_args = target.send_preview.call_args
+        assert call_args.args[0] is loading_msg
+        assert isinstance(call_args.args[1], discord.Embed)
+        assert isinstance(call_args.args[2], PreviewView)
+
+    @pytest.mark.asyncio
+    async def test_target_send_error_called_on_transform_failure(self, mock_pipeline):
+        mock_pipeline.transform.run.side_effect = RuntimeError("Gemini 503")
+        interaction = _mock_interaction()
+        target = AsyncMock(spec=ResponseTarget)
+        target.channel_id = None
+        loading_msg = AsyncMock()
+        interaction.followup.send.return_value = loading_msg
+
+        await mock_pipeline.run(
+            interaction,
+            repo="owner/repo",
+            topic="bug",
+            messages=["user1: msg"],
+            latest_message_link=None,
+            target=target,
+        )
+        target.send_error.assert_awaited_once()
+        call_args = target.send_error.call_args
+        assert "Gemini 503" in call_args.args[1].description
+        assert isinstance(call_args.args[2], ErrorView)
+
+    @pytest.mark.asyncio
+    async def test_target_send_error_called_on_repo_not_installed(self, mock_pipeline):
+        mock_pipeline.github.check_repo_installation = AsyncMock(
+            side_effect=RepoNotInstalled("acme", "widgets")
+        )
+        interaction = _mock_interaction()
+        target = AsyncMock(spec=ResponseTarget)
+        target.channel_id = None
+        loading_msg = AsyncMock()
+        interaction.followup.send.return_value = loading_msg
+
+        await mock_pipeline.run(
+            interaction,
+            repo="acme/widgets",
+            topic="bug",
+            messages=["user1: msg"],
+            latest_message_link=None,
+            target=target,
+        )
+        target.send_error.assert_awaited_once()
+        embed = target.send_error.call_args.args[1]
+        assert "not installed" in embed.description.lower()
+
+    @pytest.mark.asyncio
+    async def test_target_channel_id_stored_in_cached_extra(self, mock_pipeline):
+        interaction = _mock_interaction()
+        target = AsyncMock(spec=ResponseTarget)
+        target.channel_id = 99999
+        loading_msg = AsyncMock()
+        interaction.followup.send.return_value = loading_msg
+
+        await mock_pipeline.run(
+            interaction,
+            repo="owner/repo",
+            topic="bug",
+            messages=["user1: msg"],
+            latest_message_link=None,
+            target=target,
+        )
+        from src.cogs.ui import get_cached_pipeline_data, ConfirmButton
+
+        view = target.send_preview.call_args.args[2]
+        confirm_btn = [c for c in view.children if isinstance(c, ConfirmButton)][0]
+        cached = get_cached_pipeline_data(confirm_btn.cache_key)
+        assert cached.extra["channel_id"] == 99999
+
+    @pytest.mark.asyncio
+    async def test_no_channel_id_in_extra_when_target_is_none(self, mock_pipeline):
+        interaction = _mock_interaction()
+        loading_msg = AsyncMock()
+        interaction.followup.send.return_value = loading_msg
+
+        await mock_pipeline.run(
+            interaction,
+            repo="owner/repo",
+            topic="bug",
+            messages=["user1: msg"],
+            latest_message_link=None,
+            target=None,
+        )
+        from src.cogs.ui import get_cached_pipeline_data, ConfirmButton
+
+        view = loading_msg.edit.call_args.kwargs["view"]
+        confirm_btn = [c for c in view.children if isinstance(c, ConfirmButton)][0]
+        cached = get_cached_pipeline_data(confirm_btn.cache_key)
+        assert "channel_id" not in cached.extra
+
+    @pytest.mark.asyncio
+    async def test_default_target_edits_loading_msg(self, mock_pipeline):
+        """When target is None, preview goes to the loading message (existing behavior)."""
+        interaction = _mock_interaction()
+        loading_msg = AsyncMock()
+        interaction.followup.send.return_value = loading_msg
+
+        await mock_pipeline.run(
+            interaction,
+            repo="owner/repo",
+            topic="bug",
+            messages=["user1: msg"],
+            latest_message_link=None,
+            target=None,
+        )
+        loading_msg.edit.assert_awaited_once()
+        edit_kwargs = loading_msg.edit.call_args.kwargs
+        assert "# Title" in edit_kwargs["embed"].description
+
+
+# ------------------------------------------------------------------
+# on_confirm / on_output_retry channel_id routing
+# ------------------------------------------------------------------
+
+
+class TestOnConfirmChannelRouting:
+    @pytest.mark.asyncio
+    async def test_posts_to_original_channel_via_channel_id(self):
+        pipeline = IssuePipeline(transform=FakeTransform(), github=FakeGitHubClient())
+        cached = make_cached(channel_id=55555)
+        interaction = _mock_interaction()
+        interaction.message = AsyncMock()
+        interaction.message.embeds = [
+            discord.Embed(description="# Title\nBody text")
+        ]
+
+        await pipeline.on_confirm(interaction, cached)
+
+        interaction.client.get_channel.assert_called_once_with(55555)
+        channel = interaction.client.get_channel.return_value
+        channel.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_interaction_channel_when_no_channel_id(self):
+        pipeline = IssuePipeline(transform=FakeTransform(), github=FakeGitHubClient())
+        cached = make_cached(channel_id=None)
+        interaction = _mock_interaction()
+        interaction.message = AsyncMock()
+        interaction.message.embeds = [
+            discord.Embed(description="# Title\nBody text")
+        ]
+
+        await pipeline.on_confirm(interaction, cached)
+
+        interaction.client.get_channel.assert_not_called()
+        interaction.channel.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_github_error_propagates_channel_id_in_payload(self):
+        github = FakeGitHubClient()
+        github.create_issue = _raise_runtime
+        pipeline = IssuePipeline(transform=FakeTransform(), github=github)
+        cached = make_cached(channel_id=55555)
+        interaction = _mock_interaction()
+        interaction.message = AsyncMock()
+        interaction.message.embeds = [
+            discord.Embed(description="# Title\nBody text")
+        ]
+
+        await pipeline.on_confirm(interaction, cached)
+
+        from src.cogs.ui import get_cached_pipeline_data, OutputErrorView
+
+        view = interaction.response.edit_message.call_args.kwargs["view"]
+        assert isinstance(view, OutputErrorView)
+        retry_btn = view.children[0]
+        new_cached = get_cached_pipeline_data(retry_btn.retry_key)
+        assert new_cached.payload["channel_id"] == 55555
+
+
+class TestOnOutputRetryChannelRouting:
+    @pytest.mark.asyncio
+    async def test_posts_to_original_channel_via_channel_id(self):
+        from src.models import CachedOutputData
+
+        pipeline = IssuePipeline(transform=FakeTransform(), github=FakeGitHubClient())
+        cached = CachedOutputData(
+            cmd_type="issue",
+            payload={
+                "title": "T", "body": "B", "owner": "o", "repo": "r",
+                "channel_id": 55555,
+            },
+        )
+        interaction = _mock_interaction()
+
+        await pipeline.on_output_retry(interaction, cached)
+
+        interaction.client.get_channel.assert_called_once_with(55555)
+        channel = interaction.client.get_channel.return_value
+        channel.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_interaction_channel_when_no_channel_id(self):
+        from src.models import CachedOutputData
+
+        pipeline = IssuePipeline(transform=FakeTransform(), github=FakeGitHubClient())
+        cached = CachedOutputData(
+            cmd_type="issue",
+            payload={"title": "T", "body": "B", "owner": "o", "repo": "r"},
+        )
+        interaction = _mock_interaction()
+
+        await pipeline.on_output_retry(interaction, cached)
+
+        interaction.client.get_channel.assert_not_called()
+        interaction.channel.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_failure_propagates_channel_id_in_payload(self):
+        from src.models import CachedOutputData
+
+        github = FakeGitHubClient()
+        github.create_issue = _raise_runtime
+        pipeline = IssuePipeline(transform=FakeTransform(), github=github)
+        cached = CachedOutputData(
+            cmd_type="issue",
+            payload={
+                "title": "T", "body": "B", "owner": "o", "repo": "r",
+                "channel_id": 55555,
+            },
+        )
+        interaction = _mock_interaction()
+
+        await pipeline.on_output_retry(interaction, cached)
+
+        from src.cogs.ui import get_cached_pipeline_data
+
+        view = interaction.response.edit_message.call_args.kwargs["view"]
+        retry_btn = view.children[0]
+        new_cached = get_cached_pipeline_data(retry_btn.retry_key)
+        assert new_cached.payload["channel_id"] == 55555
 
 
 # ------------------------------------------------------------------

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,127 @@
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from src.cogs.response import DmResponseTarget, ResponseTarget
+
+
+class TestResponseTarget:
+    @pytest.mark.asyncio
+    async def test_send_preview_edits_loading_message(self):
+        target = ResponseTarget()
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="preview")
+        view = AsyncMock()
+
+        await target.send_preview(loading_msg, embed, view)
+
+        loading_msg.edit.assert_awaited_once_with(embed=embed, view=view)
+
+    @pytest.mark.asyncio
+    async def test_send_error_edits_loading_message(self):
+        target = ResponseTarget()
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="error")
+        view = AsyncMock()
+
+        await target.send_error(loading_msg, embed, view)
+
+        loading_msg.edit.assert_awaited_once_with(embed=embed, view=view)
+
+    @pytest.mark.asyncio
+    async def test_send_error_without_view(self):
+        target = ResponseTarget()
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="error")
+
+        await target.send_error(loading_msg, embed)
+
+        loading_msg.edit.assert_awaited_once_with(embed=embed)
+
+    def test_channel_id_is_none(self):
+        target = ResponseTarget()
+        assert target.channel_id is None
+
+
+class TestDmResponseTarget:
+    def test_channel_id_returns_origin(self):
+        user = AsyncMock()
+        target = DmResponseTarget(user, origin_channel_id=99999)
+        assert target.channel_id == 99999
+
+    @pytest.mark.asyncio
+    async def test_send_preview_sends_to_dm_and_edits_stub(self):
+        user = AsyncMock()
+        target = DmResponseTarget(user, origin_channel_id=12345)
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="preview")
+        view = AsyncMock()
+
+        await target.send_preview(loading_msg, embed, view)
+
+        user.send.assert_awaited_once_with(embed=embed, view=view)
+        loading_msg.edit.assert_awaited_once()
+        edit_kwargs = loading_msg.edit.call_args.kwargs
+        assert "check your dms" in edit_kwargs["content"].lower()
+        assert edit_kwargs["embed"] is None
+
+    @pytest.mark.asyncio
+    async def test_send_error_sends_to_dm_and_edits_stub(self):
+        user = AsyncMock()
+        target = DmResponseTarget(user, origin_channel_id=12345)
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="error")
+        view = AsyncMock()
+
+        await target.send_error(loading_msg, embed, view)
+
+        user.send.assert_awaited_once_with(embed=embed, view=view)
+        loading_msg.edit.assert_awaited_once()
+        edit_kwargs = loading_msg.edit.call_args.kwargs
+        assert "check your dms" in edit_kwargs["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_send_error_without_view(self):
+        user = AsyncMock()
+        target = DmResponseTarget(user, origin_channel_id=12345)
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="error")
+
+        await target.send_error(loading_msg, embed)
+
+        user.send.assert_awaited_once_with(embed=embed)
+
+    @pytest.mark.asyncio
+    async def test_send_preview_forbidden_falls_back(self):
+        user = AsyncMock()
+        user.send.side_effect = discord.Forbidden(
+            AsyncMock(status=403), "Cannot send messages to this user"
+        )
+        target = DmResponseTarget(user, origin_channel_id=12345)
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="preview")
+        view = AsyncMock()
+
+        await target.send_preview(loading_msg, embed, view)
+
+        loading_msg.edit.assert_awaited_once()
+        edit_kwargs = loading_msg.edit.call_args.kwargs
+        assert "dm" in edit_kwargs["content"].lower()
+        assert edit_kwargs["embed"] is None
+
+    @pytest.mark.asyncio
+    async def test_send_error_forbidden_falls_back(self):
+        user = AsyncMock()
+        user.send.side_effect = discord.Forbidden(
+            AsyncMock(status=403), "Cannot send messages to this user"
+        )
+        target = DmResponseTarget(user, origin_channel_id=12345)
+        loading_msg = AsyncMock()
+        embed = discord.Embed(description="error")
+
+        await target.send_error(loading_msg, embed)
+
+        loading_msg.edit.assert_awaited_once()
+        edit_kwargs = loading_msg.edit.call_args.kwargs
+        assert "dm" in edit_kwargs["content"].lower()


### PR DESCRIPTION
Context menu (modal) invocations were losing their ephemeral messages at the bottom of the channel, if you had been scrolled up far enough, because the ephemeral messages were only stored client side and apparently being scrolled up high enough busts the client cache. 

This change now instead sends the preview to the user's DMs instead of as an ephemeral message. Slash command flows remain ephemeral (unchanged).
